### PR TITLE
Update session.rb

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -179,6 +179,17 @@ module ActionDispatch
         end
       end
 
+      def start kwargs
+        kwargs.to_a.each do |kwarg| 
+          @key = kwarg[0]
+          @val = kwarg[1]
+          if self[@key] == nil
+            self[@key] = @val
+          end
+        end
+        self
+      end
+      
       def exists?
         return @exists unless @exists.nil?
         @exists = @by.send(:session_exists?, @req)


### PR DESCRIPTION
## Summary

Creates the 'start' method, available to ActionDispatch::Request::Session objects.  This method allows multiple session variables to be initialized in a single line of code.  Default values can be assigned to session keys when an application starts, but are overridden by other methods (similar to the ||= operator).  Practical uses include form data persistence where the method rendering the form can populate each field with session variables, and then modify them if the form is submitted multiple times (e.g. because of invalid data).  If the session has been 'start'ed with default values, these will appear in the form fields, and the application will not raise an error that the requested keys do not exist.

## Sample Implementation
```
class MainController < ApplicationController

  def register
    session.start validation_errors: [], username: "", email: ""
    @validation_errors = session[:validation_errors]
    @username = session[:username]
    @email = session[:email]
    render "register"
  end

  #...

end
```